### PR TITLE
Make cargo build in the root workspace dir work

### DIFF
--- a/program/src/main.rs
+++ b/program/src/main.rs
@@ -5,7 +5,9 @@
 //
 // Under the hood, we wrap your main function with some extra code so that it behaves properly
 // inside the zkVM.
-#![no_main]
+#![cfg_attr(target_os = "zkvm", no_main)]
+
+#[cfg(target_os = "zkvm")]
 sp1_zkvm::entrypoint!(main);
 
 use alloy_sol_types::SolType;


### PR DESCRIPTION
This commit makes it possible to build the program under a normal `target_os`. Previously cargo build would produce a linker error because of the custom zkvm entry point code being unconditionally used.