### PR TITLE
feat: update `cargo prove vkey` usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ inside Solidity.
 To retrieve your `programVKey` for your on-chain contract, run the following command:
 
 ```sh
-cargo prove vkey --elf elf/riscv32im-succinct-zkvm-elf
+cargo prove vkey --program fibonacci-program
 ```
 
 ## Using the Prover Network


### PR DESCRIPTION
Update README to match the newly added `--program` arg