### PR TITLE
Minimize produced RISC-V binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,9 @@ resolver = "2"
 
 [workspace.dependencies]
 alloy-sol-types = "0.7.7"
+
+## Uncomment to minimize the size of produced RISC-V binary
+#[profile.release]
+#lto = "fat"
+#opt-level = "s"
+#strip = "symbols"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ cd program
 cargo prove build
 ```
 
+The produced binary can be found in `target/elf-compilation/riscv32im-succinct-zkvm-elf/release`. 
+To reduce the size of the binary, uncomment the following lines in `Cargo.toml` (in the project root):
+
+```toml
+[profile.release]
+lto = "fat"
+opt-level = "s"
+strip = "symbols"
+```
+
 ### Execute the Program
 
 To run the program without generating a proof:


### PR DESCRIPTION
Add instructions on how to minimize produced RISC-V binary size.