### PR TITLE
refactor: Clap attribute macros from #[clap(...)] to #[arg(...)] and #[command(...)] in v4.x 

### DIFF
--- a/script/src/bin/evm.rs
+++ b/script/src/bin/evm.rs
@@ -11,7 +11,7 @@
 //! ```
 
 use alloy_sol_types::SolType;
-use clap::{Parser, ValueEnum};
+use clap::{Parser, ValueEnum, Args};
 use fibonacci_lib::PublicValuesStruct;
 use serde::{Deserialize, Serialize};
 use sp1_sdk::{
@@ -24,11 +24,11 @@ pub const FIBONACCI_ELF: &[u8] = include_elf!("fibonacci-program");
 
 /// The arguments for the EVM command.
 #[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 struct EVMArgs {
-    #[clap(long, default_value = "20")]
+    #[arg(long, default_value = "20")]
     n: u32,
-    #[clap(long, value_enum, default_value = "groth16")]
+    #[arg(long, value_enum, default_value = "groth16")]
     system: ProofSystem,
 }
 

--- a/script/src/bin/main.rs
+++ b/script/src/bin/main.rs
@@ -11,7 +11,7 @@
 //! ```
 
 use alloy_sol_types::SolType;
-use clap::Parser;
+use clap::{Parser, Args};
 use fibonacci_lib::PublicValuesStruct;
 use sp1_sdk::{include_elf, ProverClient, SP1Stdin};
 
@@ -20,15 +20,15 @@ pub const FIBONACCI_ELF: &[u8] = include_elf!("fibonacci-program");
 
 /// The arguments for the command.
 #[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 struct Args {
-    #[clap(long)]
+    #[arg(long)]
     execute: bool,
 
-    #[clap(long)]
+    #[arg(long)]
     prove: bool,
 
-    #[clap(long, default_value = "20")]
+    #[arg(long, default_value = "20")]
     n: u32,
 }
 


### PR DESCRIPTION
This PR updates deprecated `#[clap(...)]` attributes to their modern equivalents in `clap` 4.x.
The current codebase still uses outdated syntax that has been deprecated since version 4.0.
By making this update, we ensure compatibility with future versions and maintain code quality.