### PR TITLE
Fix : SP1 hyperlink in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ that can generate a proof of any RISC-V program.
 ## Requirements
 
 - [Rust](https://rustup.rs/)
-- [SP1](https://docs.succinct.xyz/getting-started/install.html)
+- [SP1](https://docs.succinct.xyz/docs/sp1/getting-started/install)
 
 ## Running the Project
 


### PR DESCRIPTION
Fixed SP1 hyperlink in README from 
`https://docs.succinct.xyz/getting-started/install.html` (404 Not found)
 to
 `https://docs.succinct.xyz/docs/sp1/getting-started/install`